### PR TITLE
Fixed a typo and updated the URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ companyReferences:
 
 perks:
 
-- perl: {name: Codacy, uri: 'https://www.codacy.com/'}
+- perk: {name: Codacy, uri: 'https://www.codacy.com/pricing'}
   description: Automated Code Review for Scala, Java, JavaScript, Python, Ruby and PHP. Static Analysis, Code Complexity, Code Duplication and Code Coverage changes in every commit and pull request. Free for open source projects.
   categories: [Code Quality, Code analyzer, Automated Code Review]
   platforms: [Scala, Java, JavaScript, Python, Ruby, PHP, CoffeeScript, CSS]


### PR DESCRIPTION
Fixed a typo (s/perl/perk/) and updated the URL to point to where Codacy says that it's free for OSS projects.